### PR TITLE
fix: Update Babel plugin for React Native Reanimated to use worklets

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -4,6 +4,8 @@ module.exports = function (api) {
     presets: [
       "babel-preset-expo"
     ],
-    plugins: []
+    plugins: [
+      "react-native-worklets/plugin"
+    ]
   };
 };


### PR DESCRIPTION
- Updated babel.config.js to use 'react-native-worklets/plugin' instead of deprecated 'react-native-reanimated/plugin'
- Resolves warning: "Seems like you are using a Babel plugin `react-native-reanimated/plugin`. It was moved to `react-native-worklets` package."
- react-native-worklets package already available as transitive dependency through nativewind → react-native-css-interop → react-native-reanimated

🤖 Generated with [Claude Code](https://claude.ai/code)